### PR TITLE
Changes to package.json for electron-builder integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pretest": "npm run lint && gulp build --env=test",
     "release": "npm run lint && gulp release --env=production",
     "start": "gulp start",
-    "test": "electron-mocha build"
+    "test": "electron-mocha build",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "postinstall": "electron-builder install-app-deps"

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "asar": "0.13.0",
     "body-parser": "1.17.2",
     "chai": "4.0.2",
     "cookie-parser": "1.4.3",
     "del": "2.2.2",
-    "electron": "1.6.10",
+    "electron": "1.6.11",
     "electron-connect": "0.6.1",
     "electron-mocha": "3.4.0",
+    "electron-builder": "^19.11.1",
     "express": "4.15.3",
     "fs-jetpack": "1.0.0",
     "gulp": "3.9.1",
@@ -55,5 +55,16 @@
     "release": "npm run lint && gulp release --env=production",
     "start": "gulp start",
     "test": "electron-mocha build"
+    "pack": "electron-builder --dir",
+    "dist": "electron-builder",
+    "postinstall": "electron-builder install-app-deps"
+  },
+  "build": {
+    "appId": "YOUR.APPID.GOES.HERE",
+    "directories": {
+      "app": "build"
+    }
+  },
+  "dependencies": {
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -3,8 +3,12 @@
   "productName": "A Polyonic App",
   "description": "ionic2: An Ionic project",
   "version": "1.0.0",
-  "author": "Author",
-  "copyright": "© 2016, Author",
+  "author": {
+    "name": "Your Name",
+    "email": "email@your-email.com",
+    "url": "http://yourwebsite.com"
+  },
+  "copyright": "© 2017, Your Name",
   "main": "app.js",
   "repository": {
     "type": "git",
@@ -31,7 +35,6 @@
     "body-parser": "1.17.2",
     "cookie-parser": "1.4.3",
     "express": "4.15.3",
-    "electron": "1.6.10",
     "electron-connect": "0.6.1",
     "@ionic-native/core": "3.12.1",
     "@ionic-native/splash-screen": "3.12.1",
@@ -43,15 +46,16 @@
     "pouchdb": "6.2.0",
     "rxjs": "5.4.0",
     "serve-favicon": "2.4.3",
+    "skip-map": "1.0.0",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.11"
   },
   "devDependencies": {
     "gulp": "^3.9.1",
-    "skip-map": "1.0.0",
     "@ionic/app-scripts": "1.3.7",
-    "@ionic/cli-plugin-cordova": "1.3.0",
-    "@ionic/cli-plugin-ionic-angular": "1.3.0",
+    "@ionic/cli-plugin-cordova": "1.4.0",
+    "@ionic/cli-plugin-gulp": "1.0.1",
+    "@ionic/cli-plugin-ionic-angular": "1.3.1",
     "typescript": "2.3.4"
   },
   "osx": {


### PR DESCRIPTION
I ran into a lot of problems trying to build installers / executables that included native modules (specifically node-serialport). I think incorporating some of these changes may make it easier going for others in my position. 