### PR TITLE
A few small updates to package scripts definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "start": "gulp start",
     "test": "electron-mocha build",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder",
-    "postinstall": "electron-builder install-app-deps"
+    "dist": "electron-builder"
   },
   "build": {
     "appId": "YOUR.APPID.GOES.HERE",
@@ -66,5 +65,6 @@
     }
   },
   "dependencies": {
+    "asar": "^0.13.0"
   }
 }


### PR DESCRIPTION
- duplicate postinstall script
- asar package needed by, e.g. windows build